### PR TITLE
Invoke buildDevelopment with the --version <...> switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ http-pub/%.html: http-pub/%.html.template $(shell find http-pub -name '*.js' -o 
 	buildDevelopment \
 		--cssimports \
 		--root=http-pub \
+		--version `git describe --long --tags --always 2>/dev/null || echo unknown` \
 		${LABELS} \
 		$<
 


### PR DESCRIPTION
Invoke buildDevelopment with the --version <...> switch so the git tag/commit SHA is included as a <meta http-equiv='Content-Version' content='...'> tag in the output HTML. Only has an effect for assetgraph-builder >= 0.2.20.
